### PR TITLE
Feature user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,10 @@ out/
 src/main/resources/application.properties
 src/main/resources/application.yml
 
+# Ensure resources folder is tracked
+!src/main/resources/
+!src/main/resources/.keep
+
 # MacOS
 .DS_Store
 

--- a/build.gradle
+++ b/build.gradle
@@ -27,8 +27,10 @@ dependencies {
     implementation 'com.aventrix.jnanoid:jnanoid:2.0.0'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
-    // JWT 관련 라이브러리 (jjwt)
-    implementation 'io.jsonwebtoken:jjwt:0.12.6'
+    // JWT 관련 라이브러리 (jjwt 최신 설정)
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,9 @@ dependencies {
     implementation 'com.aventrix.jnanoid:jnanoid:2.0.0'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    // JWT 관련 라이브러리 (jjwt)
+    implementation 'io.jsonwebtoken:jjwt:0.12.6'
+
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/p1/nomnom/food/entity/Food.java
+++ b/src/main/java/com/p1/nomnom/food/entity/Food.java
@@ -1,6 +1,6 @@
 package com.p1.nomnom.food.entity;
 
-import com.p1.nomnom.food.dto.request.FoodRequestDto;
+//import com.p1.nomnom.food.dto.request.FoodRequestDto;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -40,11 +40,12 @@ public class Food {
     // --- jpg나 png로 들어온 것을 로컬에 저장하든 클라우드에 저장하든 해야함.
     private String image; // 음식 사진 url
 
-    public Food(String storeId, FoodRequestDto requestDto) {
+
+    /*public Food(String storeId, FoodRequestDto requestDto) {
         this.storeId = storeId;
         this.name = requestDto.getName();
         this.description = requestDto.getDescription();
         this.price = requestDto.getPrice();
         this.image = requestDto.getImage();
-    }
+    }*/
 }

--- a/src/main/java/com/p1/nomnom/security/WebSecurityConfig.java
+++ b/src/main/java/com/p1/nomnom/security/WebSecurityConfig.java
@@ -18,6 +18,9 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity // Spring Security 활성화
@@ -66,13 +69,22 @@ public class WebSecurityConfig {
         // 권한 설정
         http.authorizeHttpRequests(auth -> auth
                 .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll() // 정적 리소스 접근 허용
-                .requestMatchers("/", "/api/user/**").permitAll() // 회원가입 및 로그인 API는 모두 허용
+                .requestMatchers("/api/user/login", "/api/user/signup", "/api/user/token/refresh").permitAll()
                 .requestMatchers("/api/customer/**").hasRole("CUSTOMER") // 고객 전용 API
                 .requestMatchers("/api/owner/**").hasRole("OWNER") // 가게 사장 전용 API
                 .requestMatchers("/api/manager/**").hasRole("MANAGER") // 관리자 전용 API
-                .requestMatchers("/api/master/**").hasRole("MASTER") // 최상위 관리자 전용 API
+                .requestMatchers("/api/master/**").hasRole("MASTER") // 최상위 관리자(ADMIN) 전용 API
                 .anyRequest().authenticated() // 그 외 모든 요청은 인증 필요
         );
+
+        // CORS 설정 추가
+        http.cors(cors -> cors.configurationSource(request -> {
+            CorsConfiguration config = new CorsConfiguration();
+            config.setAllowedOrigins(List.of("*"));
+            config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+            config.setAllowedHeaders(List.of("Authorization", "Content-Type", "Refresh-Token"));
+            return config;
+        }));
 
         // JWT 필터 추가 (Authorization -> Authentication 순서)
         http.addFilterBefore(jwtAuthorizationFilter(), UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/p1/nomnom/security/WebSecurityConfig.java
+++ b/src/main/java/com/p1/nomnom/security/WebSecurityConfig.java
@@ -1,0 +1,81 @@
+package com.p1.nomnom.security;
+
+import com.p1.nomnom.security.jwt.JwtUtil;
+import com.p1.nomnom.security.jwt.JwtAuthenticationFilter;
+import com.p1.nomnom.security.jwt.JwtAuthorizationFilter;
+import com.p1.nomnom.security.userdetails.UserDetailsServiceImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity // Spring Security 활성화
+@RequiredArgsConstructor
+public class WebSecurityConfig {
+
+    private final JwtUtil jwtUtil;
+    private final UserDetailsServiceImpl userDetailsService;
+    private final AuthenticationConfiguration authenticationConfiguration;
+
+    // 비밀번호 암호화 설정
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    // AuthenticationManager 설정
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+
+    // 로그인 요청 시 인증 필터
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() throws Exception {
+        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtUtil);
+        filter.setAuthenticationManager(authenticationManager(authenticationConfiguration));
+        return filter;
+    }
+
+    // JWT 토큰 검증 필터
+    @Bean
+    public JwtAuthorizationFilter jwtAuthorizationFilter() {
+        return new JwtAuthorizationFilter(jwtUtil, userDetailsService);
+    }
+
+    // Spring Security 설정
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.csrf(csrf -> csrf.disable()); // CSRF 비활성화 (JWT 방식 사용)
+
+        // 세션 관리 - STATELESS 모드 (JWT 사용 시 필수)
+        http.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        // 권한 설정
+        http.authorizeHttpRequests(auth -> auth
+                .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll() // 정적 리소스 접근 허용
+                .requestMatchers("/", "/api/user/**").permitAll() // 회원가입 및 로그인 API는 모두 허용
+                .requestMatchers("/api/customer/**").hasRole("CUSTOMER") // 고객 전용 API
+                .requestMatchers("/api/owner/**").hasRole("OWNER") // 가게 사장 전용 API
+                .requestMatchers("/api/manager/**").hasRole("MANAGER") // 관리자 전용 API
+                .requestMatchers("/api/master/**").hasRole("MASTER") // 최상위 관리자 전용 API
+                .anyRequest().authenticated() // 그 외 모든 요청은 인증 필요
+        );
+
+        // JWT 필터 추가 (Authorization -> Authentication 순서)
+        http.addFilterBefore(jwtAuthorizationFilter(), UsernamePasswordAuthenticationFilter.class);
+        http.addFilterBefore(jwtAuthenticationFilter(), JwtAuthorizationFilter.class);
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/p1/nomnom/security/WebSecurityConfig.java
+++ b/src/main/java/com/p1/nomnom/security/WebSecurityConfig.java
@@ -4,6 +4,7 @@ import com.p1.nomnom.security.jwt.JwtUtil;
 import com.p1.nomnom.security.jwt.JwtAuthenticationFilter;
 import com.p1.nomnom.security.jwt.JwtAuthorizationFilter;
 import com.p1.nomnom.security.userdetails.UserDetailsServiceImpl;
+import com.p1.nomnom.user.repository.RefreshTokenRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
@@ -26,6 +27,7 @@ public class WebSecurityConfig {
     private final JwtUtil jwtUtil;
     private final UserDetailsServiceImpl userDetailsService;
     private final AuthenticationConfiguration authenticationConfiguration;
+    private final RefreshTokenRepository refreshTokenRepository;
 
     // 비밀번호 암호화 설정
     @Bean
@@ -42,7 +44,7 @@ public class WebSecurityConfig {
     // 로그인 요청 시 인증 필터
     @Bean
     public JwtAuthenticationFilter jwtAuthenticationFilter() throws Exception {
-        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtUtil);
+        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtUtil, refreshTokenRepository);
         filter.setAuthenticationManager(authenticationManager(authenticationConfiguration));
         return filter;
     }
@@ -50,7 +52,7 @@ public class WebSecurityConfig {
     // JWT 토큰 검증 필터
     @Bean
     public JwtAuthorizationFilter jwtAuthorizationFilter() {
-        return new JwtAuthorizationFilter(jwtUtil, userDetailsService);
+        return new JwtAuthorizationFilter(jwtUtil, userDetailsService, refreshTokenRepository);
     }
 
     // Spring Security 설정

--- a/src/main/java/com/p1/nomnom/security/aop/RoleCheck.java
+++ b/src/main/java/com/p1/nomnom/security/aop/RoleCheck.java
@@ -1,0 +1,13 @@
+package com.p1.nomnom.security.aop;
+
+import com.p1.nomnom.user.entity.UserRoleEnum;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RoleCheck {
+    UserRoleEnum[] value(); // 특정 역할만 허용 (배열)
+}

--- a/src/main/java/com/p1/nomnom/security/aop/RoleCheckAspect.java
+++ b/src/main/java/com/p1/nomnom/security/aop/RoleCheckAspect.java
@@ -1,0 +1,52 @@
+package com.p1.nomnom.security.aop;
+
+import com.p1.nomnom.security.jwt.JwtUtil;
+import com.p1.nomnom.user.entity.User;
+import com.p1.nomnom.user.entity.UserRoleEnum;
+import com.p1.nomnom.user.repository.UserRepository;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ResponseStatusException;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RoleCheckAspect {
+
+    private final JwtUtil jwtUtil;
+    private final UserRepository userRepository;
+    private final HttpServletRequest request;
+
+    @Around("@annotation(roleCheck)") // @RoleCheck가 붙은 메서드 실행 전에 AOP 동작
+    public Object checkRole(ProceedingJoinPoint joinPoint, RoleCheck roleCheck) throws Throwable {
+        String token = jwtUtil.getJwtFromHeader(request);
+        if (token == null || !jwtUtil.validateToken(token)) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다.");
+        }
+
+        Claims claims = jwtUtil.getUserInfoFromToken(token);
+        String username = claims.getSubject();
+
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."));
+
+        UserRoleEnum userRole = user.getRole();
+        for (UserRoleEnum requiredRole : roleCheck.value()) {
+            if (userRole == requiredRole) {
+                log.info("✅ 접근 허용: {} (요구 역할: {})", userRole, requiredRole);
+                return joinPoint.proceed(); // 역할이 맞으면 API 실행
+            }
+        }
+
+        log.warn("⛔ 접근 거부: {} (요구 역할: {})", userRole, roleCheck.value());
+        throw new ResponseStatusException(HttpStatus.FORBIDDEN, "접근 권한이 없습니다.");
+    }
+}

--- a/src/main/java/com/p1/nomnom/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/p1/nomnom/security/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,75 @@
+package com.p1.nomnom.security.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.p1.nomnom.security.userdetails.UserDetailsImpl;
+import com.p1.nomnom.user.entity.User;
+import com.p1.nomnom.user.entity.UserRoleEnum;
+import com.p1.nomnom.user.repository.UserRepository;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.io.IOException;
+import java.util.Optional;
+
+@Slf4j(topic = "로그인 및 JWT 생성")
+public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+    private final JwtUtil jwtUtil;
+    private final UserRepository userRepository;
+
+    public JwtAuthenticationFilter(JwtUtil jwtUtil, UserRepository userRepository) {
+        this.jwtUtil = jwtUtil;
+        this.userRepository = userRepository;
+        setFilterProcessesUrl("/api/user/login"); // 로그인 요청 URL
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+        try {
+            LoginRequestDto requestDto = new ObjectMapper().readValue(request.getInputStream(), LoginRequestDto.class);
+
+            return getAuthenticationManager().authenticate(
+                    new UsernamePasswordAuthenticationToken(
+                            requestDto.getUsername(),
+                            requestDto.getPassword(),
+                            null
+                    )
+            );
+        } catch (IOException e) {
+            log.error(e.getMessage());
+            throw new RuntimeException(e.getMessage());
+        }
+    }
+
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authResult) {
+        String username = ((UserDetailsImpl) authResult.getPrincipal()).getUsername();
+        UserRoleEnum role = ((UserDetailsImpl) authResult.getPrincipal()).getUser().getRole();
+
+        // AccessToken & RefreshToken 생성
+        String accessToken = jwtUtil.createAccessToken(username, role);
+        String refreshToken = jwtUtil.createRefreshToken();
+
+        // RefreshToken을 DB에 저장 (기존 RefreshToken이 있다면 업데이트)
+        Optional<User> userOptional = userRepository.findByUsername(username);
+        if (userOptional.isPresent()) {
+            User user = userOptional.get();
+            user.setRefreshToken(refreshToken);
+            userRepository.save(user);
+        }
+
+        // 응답 헤더에 토큰 추가
+        response.addHeader(JwtUtil.AUTHORIZATION_HEADER, accessToken);
+        response.addHeader(JwtUtil.REFRESH_HEADER, refreshToken);
+    }
+
+    @Override
+    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) {
+        response.setStatus(401);
+    }
+}

--- a/src/main/java/com/p1/nomnom/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/p1/nomnom/security/jwt/JwtAuthenticationFilter.java
@@ -52,14 +52,11 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
         String username = ((UserDetailsImpl) authResult.getPrincipal()).getUsername();
         UserRoleEnum role = ((UserDetailsImpl) authResult.getPrincipal()).getUser().getRole();
 
-        // AccessToken & RefreshToken 생성
         String accessToken = jwtUtil.createAccessToken(username, role);
-        RefreshToken refreshToken = jwtUtil.createRefreshToken(username);
+        RefreshToken refreshToken = jwtUtil.createRefreshToken(username, role);
 
-        // RefreshToken을 DB에 저장 (기존 RefreshToken이 있다면 업데이트)
         refreshTokenRepository.save(refreshToken);
 
-        // 응답 헤더에 토큰 추가
         response.addHeader(JwtUtil.AUTHORIZATION_HEADER, accessToken);
         response.addHeader(JwtUtil.REFRESH_TOKEN_HEADER, refreshToken.getRefreshToken());
     }

--- a/src/main/java/com/p1/nomnom/security/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/com/p1/nomnom/security/jwt/JwtAuthorizationFilter.java
@@ -1,0 +1,79 @@
+package com.p1.nomnom.security.jwt;
+
+import com.p1.nomnom.security.userdetails.UserDetailsServiceImpl;
+import com.p1.nomnom.user.entity.User;
+import com.p1.nomnom.user.repository.UserRepository;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Optional;
+
+@Slf4j(topic = "JWT 검증 및 인가")
+public class JwtAuthorizationFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+    private final UserDetailsServiceImpl userDetailsService;
+    private final UserRepository userRepository;
+
+    public JwtAuthorizationFilter(JwtUtil jwtUtil, UserDetailsServiceImpl userDetailsService, UserRepository userRepository) {
+        this.jwtUtil = jwtUtil;
+        this.userDetailsService = userDetailsService;
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain filterChain) throws ServletException, IOException {
+        String accessToken = jwtUtil.getJwtFromHeader(req);
+        String refreshToken = jwtUtil.getRefreshTokenFromHeader(req);
+
+        if (StringUtils.hasText(accessToken)) {
+            if (jwtUtil.validateToken(accessToken)) {
+                Claims info = jwtUtil.getUserInfoFromToken(accessToken);
+                setAuthentication(info.getSubject());
+            } else if (StringUtils.hasText(refreshToken) && jwtUtil.validateToken(refreshToken)) {
+                // AccessToken이 만료되고 RefreshToken이 유효하면 새로운 AccessToken 발급
+                Optional<User> userOptional = userRepository.findByRefreshToken(refreshToken);
+                if (userOptional.isPresent()) {
+                    User user = userOptional.get();
+                    String newAccessToken = jwtUtil.createAccessToken(user.getUsername(), user.getRole());
+                    res.addHeader(JwtUtil.AUTHORIZATION_HEADER, newAccessToken);
+
+                    setAuthentication(user.getUsername());
+                } else {
+                    log.error("유효하지 않은 Refresh Token입니다.");
+                }
+            } else {
+                log.error("토큰이 유효하지 않습니다.");
+            }
+        }
+
+        filterChain.doFilter(req, res);
+    }
+
+    // 인증 처리
+    private void setAuthentication(String username) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        Authentication authentication = createAuthentication(username);
+        context.setAuthentication(authentication);
+
+        SecurityContextHolder.setContext(context);
+    }
+
+    // 인증 객체 생성
+    private Authentication createAuthentication(String username) {
+        UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+        return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+    }
+}

--- a/src/main/java/com/p1/nomnom/security/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/com/p1/nomnom/security/jwt/JwtAuthorizationFilter.java
@@ -44,6 +44,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
                 Claims info = jwtUtil.getUserInfoFromToken(accessToken);
                 setAuthentication(info.getSubject());
             } else if (StringUtils.hasText(refreshToken) && jwtUtil.validateToken(refreshToken)) {
+
                 // AccessToken이 만료되고 RefreshToken이 유효하면 새로운 AccessToken 발급
                 Optional<RefreshToken> storedToken = refreshTokenRepository.findByRefreshToken(refreshToken);
                 if (storedToken.isPresent()) {

--- a/src/main/java/com/p1/nomnom/security/jwt/JwtUtil.java
+++ b/src/main/java/com/p1/nomnom/security/jwt/JwtUtil.java
@@ -1,0 +1,121 @@
+package com.p1.nomnom.security.jwt;
+
+import com.p1.nomnom.user.entity.UserRoleEnum;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import javax.crypto.SecretKey;
+import java.util.Base64;
+import java.util.Date;
+
+@Slf4j(topic = "JwtUtil")
+@Component
+public class JwtUtil {
+    // Header KEY 값
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    public static final String REFRESH_TOKEN_HEADER = "Refresh-Token"; // Refresh Token을 위한 헤더
+    public static final String AUTHORIZATION_KEY = "role"; // 사용자 권한
+    public static final String BEARER_PREFIX = "Bearer ";
+
+    // JWT 만료시간 설정 (AccessToken: 15분, RefreshToken: 7일)
+    private final long ACCESS_TOKEN_TIME = 15 * 60 * 1000L;
+    private final long REFRESH_TOKEN_TIME = 7 * 24 * 60 * 60 * 1000L;
+
+    @Value("${jwt.secret.key}") // Base64 Encode 한 SecretKey
+    private String secretKey;
+    private SecretKey key;
+    private final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
+
+    @PostConstruct
+    public void init() {
+        byte[] bytes = Base64.getDecoder().decode(secretKey);
+        key = Keys.hmacShaKeyFor(bytes);
+    }
+
+    // ✅ Access Token 생성 (Role 포함)
+    public String createAccessToken(String username, UserRoleEnum role) {
+        return BEARER_PREFIX + createToken(username, role.name(), ACCESS_TOKEN_TIME);
+    }
+
+    // ✅ Refresh Token 생성 (Role 없음)
+    public String createRefreshToken(String username) {
+        return BEARER_PREFIX + createToken(username, null, REFRESH_TOKEN_TIME);
+    }
+
+    // ✅ 공통 토큰 생성 메서드
+    private String createToken(String username, String role, long expirationTime) {
+        Claims claims = Jwts.claims().subject(username).build();
+        if (role != null) {
+            claims.put(AUTHORIZATION_KEY, role);
+        }
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(new Date()) // 발급일
+                .setExpiration(new Date(System.currentTimeMillis() + expirationTime)) // 만료 시간
+                .signWith(key, signatureAlgorithm) // 서명
+                .compact();
+    }
+
+    // ✅ 헤더에서 JWT 가져오기
+    public String getJwtFromHeader(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+    // ✅ 헤더에서 Refresh Token 가져오기
+    public String getRefreshTokenFromHeader(HttpServletRequest request) {
+        String refreshToken = request.getHeader(REFRESH_TOKEN_HEADER);
+        if (StringUtils.hasText(refreshToken) && refreshToken.startsWith(BEARER_PREFIX)) {
+            return refreshToken.substring(7);
+        }
+        return null;
+    }
+
+    // ✅ 토큰 검증
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (ExpiredJwtException e) {
+            log.warn("Expired JWT token, 만료된 JWT 토큰입니다.");
+            return false;
+        } catch (JwtException | IllegalArgumentException e) {
+            log.error("Invalid JWT token, 유효하지 않은 JWT 토큰입니다.");
+            return false;
+        }
+    }
+
+    // ✅ Access Token이 만료되었을 때 Refresh Token으로 새로운 Access Token 발급
+    public String refreshAccessToken(String refreshToken) {
+        if (!validateToken(refreshToken)) {
+            throw new IllegalArgumentException("유효하지 않은 Refresh Token입니다.");
+        }
+
+        Claims claims = getUserInfoFromToken(refreshToken);
+        String username = claims.getSubject();
+        String role = claims.get(AUTHORIZATION_KEY, String.class);
+
+        return createAccessToken(username, UserRoleEnum.valueOf(role));
+    }
+
+    // ✅ 토큰에서 사용자 정보 가져오기
+    public Claims getUserInfoFromToken(String token) {
+        return Jwts.parser().setSigningKey(key).build().parseClaimsJws(token).getBody();
+    }
+
+    // ✅ 토큰에서 Role 정보 가져오기
+    public String getRoleFromToken(String token) {
+        Claims claims = getUserInfoFromToken(token);
+        return claims.get(AUTHORIZATION_KEY, String.class);
+    }
+}

--- a/src/main/java/com/p1/nomnom/security/userdetails/UserDetailsImpl.java
+++ b/src/main/java/com/p1/nomnom/security/userdetails/UserDetailsImpl.java
@@ -31,10 +31,6 @@ public class UserDetailsImpl implements UserDetails {
         return user.getUsername();
     }
 
-    public String getRefreshToken() {
-        return user.getRefreshToken();  // RefreshToken 조회 가능하도록 추가
-    }
-
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         UserRoleEnum role = user.getRole();

--- a/src/main/java/com/p1/nomnom/security/userdetails/UserDetailsImpl.java
+++ b/src/main/java/com/p1/nomnom/security/userdetails/UserDetailsImpl.java
@@ -1,0 +1,69 @@
+package com.p1.nomnom.security.userdetails;
+
+import com.p1.nomnom.user.entity.User;
+import com.p1.nomnom.user.entity.UserRoleEnum;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class UserDetailsImpl implements UserDetails {
+
+    private final User user;
+
+    public UserDetailsImpl(User user) {
+        this.user = user;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getUsername();
+    }
+
+    public String getRefreshToken() {
+        return user.getRefreshToken();  // RefreshToken 조회 가능하도록 추가
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        UserRoleEnum role = user.getRole();
+        String authority = role.getAuthority();
+
+        SimpleGrantedAuthority simpleGrantedAuthority = new SimpleGrantedAuthority(authority);
+        Collection<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(simpleGrantedAuthority);
+
+        return authorities;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/p1/nomnom/security/userdetails/UserDetailsServiceImpl.java
+++ b/src/main/java/com/p1/nomnom/security/userdetails/UserDetailsServiceImpl.java
@@ -1,0 +1,35 @@
+package com.p1.nomnom.security.userdetails;
+
+import com.p1.nomnom.user.entity.User;
+import com.p1.nomnom.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("Not Found " + username));
+
+        return new com.p1.nomnom.security.userdetails.UserDetailsImpl(user);
+    }
+
+    // RefreshToken 기반으로 유저 정보 로드
+    public UserDetails loadUserByRefreshToken(String refreshToken) {
+        Optional<User> userOptional = userRepository.findByRefreshToken(refreshToken);
+        if (userOptional.isEmpty()) {
+            throw new UsernameNotFoundException("Invalid Refresh Token");
+        }
+        return new com.p1.nomnom.security.userdetails.UserDetailsImpl(userOptional.get());
+    }
+}

--- a/src/main/java/com/p1/nomnom/security/userdetails/UserDetailsServiceImpl.java
+++ b/src/main/java/com/p1/nomnom/security/userdetails/UserDetailsServiceImpl.java
@@ -1,6 +1,8 @@
 package com.p1.nomnom.security.userdetails;
 
+import com.p1.nomnom.user.entity.RefreshToken;
 import com.p1.nomnom.user.entity.User;
+import com.p1.nomnom.user.repository.RefreshTokenRepository;
 import com.p1.nomnom.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -15,21 +17,25 @@ import java.util.Optional;
 public class UserDetailsServiceImpl implements UserDetailsService {
 
     private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
         User user = userRepository.findByUsername(username)
                 .orElseThrow(() -> new UsernameNotFoundException("Not Found " + username));
 
-        return new com.p1.nomnom.security.userdetails.UserDetailsImpl(user);
+        return new UserDetailsImpl(user);
     }
 
-    // RefreshToken 기반으로 유저 정보 로드
+    // RefreshToken 기반으로 유저 정보 불러오기
     public UserDetails loadUserByRefreshToken(String refreshToken) {
-        Optional<User> userOptional = userRepository.findByRefreshToken(refreshToken);
-        if (userOptional.isEmpty()) {
+        Optional<RefreshToken> storedToken = refreshTokenRepository.findByRefreshToken(refreshToken);
+        if (storedToken.isEmpty()) {
             throw new UsernameNotFoundException("Invalid Refresh Token");
         }
-        return new com.p1.nomnom.security.userdetails.UserDetailsImpl(userOptional.get());
+        User user = userRepository.findByUsername(storedToken.get().getUsername())
+                .orElseThrow(() -> new UsernameNotFoundException("User not found for Refresh Token"));
+
+        return new UserDetailsImpl(user);
     }
 }

--- a/src/main/java/com/p1/nomnom/user/controller/AdminController.java
+++ b/src/main/java/com/p1/nomnom/user/controller/AdminController.java
@@ -1,0 +1,28 @@
+package com.p1.nomnom.user.controller;
+
+import com.p1.nomnom.security.aop.RoleCheck;
+import com.p1.nomnom.user.dto.RoleUpdateRequestDto;
+import com.p1.nomnom.user.entity.UserRoleEnum;
+import com.p1.nomnom.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin")
+@Slf4j
+public class AdminController {
+
+    private final UserService userService;
+
+    // MASTER 계정만 CUSTOMER의 ROLE을 OWNER 또는 MANAGER로 변경 가능
+    @RoleCheck(UserRoleEnum.MASTER) // MASTER 계정만 실행 가능
+    @PatchMapping("/role")
+    public ResponseEntity<String> changeUserRole(@RequestBody RoleUpdateRequestDto requestDto) {
+        userService.changeUserRole(requestDto);
+        log.info("사용자 권한 변경 완료: 대상 사용자={}, 변경된 ROLE={}", requestDto.getUsername(), requestDto.getNewRole());
+        return ResponseEntity.ok("사용자 권한이 " + requestDto.getNewRole() + "(으)로 변경되었습니다.");
+    }
+}

--- a/src/main/java/com/p1/nomnom/user/controller/UserController.java
+++ b/src/main/java/com/p1/nomnom/user/controller/UserController.java
@@ -1,0 +1,44 @@
+package com.p1.nomnom.user.controller;
+
+import com.p1.nomnom.security.jwt.JwtUtil;
+import com.p1.nomnom.user.dto.LoginRequestDto;
+import com.p1.nomnom.user.dto.SignupRequestDto;
+import com.p1.nomnom.user.service.AuthService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/user")
+public class UserController {
+
+    private final AuthService authService;
+    private final JwtUtil jwtUtil;
+
+    // 회원가입 API
+    @PostMapping("/signup")
+    public ResponseEntity<String> signup(@Valid @RequestBody SignupRequestDto requestDto) {
+        authService.signup(requestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body("회원가입이 완료되었습니다.");
+    }
+
+    // 로그인 API (AccessToken & RefreshToken 발급)
+    @PostMapping("/login")
+    public ResponseEntity<String> login(@RequestBody LoginRequestDto requestDto, HttpServletRequest request, HttpServletResponse response) {
+        String accessToken = authService.login(requestDto);
+
+        // HttpServletRequest에서 RefreshToken 가져오기
+        String refreshToken = jwtUtil.getRefreshTokenFromHeader(request);
+
+        // 응답 헤더에 토큰 추가
+        response.addHeader(JwtUtil.AUTHORIZATION_HEADER, accessToken);
+        response.addHeader(JwtUtil.REFRESH_TOKEN_HEADER, refreshToken);
+
+        return ResponseEntity.ok("로그인 성공!");
+    }
+}

--- a/src/main/java/com/p1/nomnom/user/controller/UserController.java
+++ b/src/main/java/com/p1/nomnom/user/controller/UserController.java
@@ -2,12 +2,14 @@ package com.p1.nomnom.user.controller;
 
 import com.p1.nomnom.security.jwt.JwtUtil;
 import com.p1.nomnom.user.dto.LoginRequestDto;
+import com.p1.nomnom.user.dto.LoginResponseDto;
 import com.p1.nomnom.user.dto.SignupRequestDto;
 import com.p1.nomnom.user.service.AuthService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -15,30 +17,63 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/user")
+@Slf4j
 public class UserController {
 
     private final AuthService authService;
     private final JwtUtil jwtUtil;
 
-    // 회원가입 API
+    // 회원가입 API (ADMIN 코드 포함)
     @PostMapping("/signup")
     public ResponseEntity<String> signup(@Valid @RequestBody SignupRequestDto requestDto) {
         authService.signup(requestDto);
+        log.info("회원가입 완료: username={}, email={}", requestDto.getUsername(), requestDto.getEmail());
         return ResponseEntity.status(HttpStatus.CREATED).body("회원가입이 완료되었습니다.");
     }
 
     // 로그인 API (AccessToken & RefreshToken 발급)
     @PostMapping("/login")
-    public ResponseEntity<String> login(@RequestBody LoginRequestDto requestDto, HttpServletRequest request, HttpServletResponse response) {
+    public ResponseEntity<LoginResponseDto> login(@RequestBody LoginRequestDto requestDto, HttpServletResponse response) {
+        log.info("로그인 시도: username={}", requestDto.getUsername());
+
         String accessToken = authService.login(requestDto);
+        String refreshToken = authService.generateAndSaveRefreshToken(requestDto.getUsername());
 
-        // HttpServletRequest에서 RefreshToken 가져오기
-        String refreshToken = jwtUtil.getRefreshTokenFromHeader(request);
+        log.info("로그인 성공: username={}", requestDto.getUsername());
+        log.info("AccessToken: {}", accessToken);
+        log.info("RefreshToken: {}", refreshToken);
 
-        // 응답 헤더에 토큰 추가
         response.addHeader(JwtUtil.AUTHORIZATION_HEADER, accessToken);
         response.addHeader(JwtUtil.REFRESH_TOKEN_HEADER, refreshToken);
 
-        return ResponseEntity.ok("로그인 성공!");
+        return ResponseEntity.ok(new LoginResponseDto(accessToken, refreshToken, "로그인 성공!"));
+    }
+
+    // AccessToken 재발급 API
+    @PostMapping("/token/refresh")
+    public ResponseEntity<LoginResponseDto> refreshAccessToken(HttpServletRequest request) {
+        log.info("AccessToken 재발급 요청");
+
+        String refreshToken = jwtUtil.getRefreshTokenFromHeader(request);
+
+        // RefreshToken이 존재하지 않으면 에러 처리
+        if (refreshToken == null || refreshToken.isBlank()) {
+            log.error("요청에서 Refresh Token을 찾을 수 없습니다.");
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(new LoginResponseDto(null, null, "Refresh Token이 필요합니다."));
+        }
+
+        try {
+            String newAccessToken = authService.refreshAccessToken(refreshToken);
+
+            log.info("AccessToken 재발급 완료: refreshToken={}", refreshToken);
+            log.info("새 AccessToken: {}", newAccessToken);
+
+            return ResponseEntity.ok(new LoginResponseDto(newAccessToken, refreshToken, "AccessToken이 재발급 되었습니다."));
+        } catch (IllegalArgumentException e) {
+            log.error("AccessToken 재발급 실패: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(new LoginResponseDto(null, null, e.getMessage()));
+        }
     }
 }

--- a/src/main/java/com/p1/nomnom/user/dto/LoginRequestDto.java
+++ b/src/main/java/com/p1/nomnom/user/dto/LoginRequestDto.java
@@ -1,0 +1,16 @@
+package com.p1.nomnom.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class LoginRequestDto {
+
+    @NotBlank(message = "사용자 이름은 필수 입력 항목입니다.")
+    private String username;
+
+    @NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
+    private String password;
+}

--- a/src/main/java/com/p1/nomnom/user/dto/LoginRequestDto.java
+++ b/src/main/java/com/p1/nomnom/user/dto/LoginRequestDto.java
@@ -13,4 +13,5 @@ public class LoginRequestDto {
 
     @NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
     private String password;
+
 }

--- a/src/main/java/com/p1/nomnom/user/dto/LoginResponseDto.java
+++ b/src/main/java/com/p1/nomnom/user/dto/LoginResponseDto.java
@@ -1,0 +1,12 @@
+package com.p1.nomnom.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LoginResponseDto {
+    private String accessToken;
+    private String refreshToken;
+    private String message;
+}

--- a/src/main/java/com/p1/nomnom/user/dto/RoleUpdateRequestDto.java
+++ b/src/main/java/com/p1/nomnom/user/dto/RoleUpdateRequestDto.java
@@ -1,0 +1,16 @@
+package com.p1.nomnom.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class RoleUpdateRequestDto {
+
+    @NotBlank
+    private String username;
+
+    @NotBlank
+    private String newRole;
+}

--- a/src/main/java/com/p1/nomnom/user/dto/SignupRequestDto.java
+++ b/src/main/java/com/p1/nomnom/user/dto/SignupRequestDto.java
@@ -35,4 +35,6 @@ public class SignupRequestDto {
 
     @NotBlank(message = "주소는 필수 입력 항목입니다.")
     private String address;
+
+    private String adminCode; // ADMIN 계정 생성을 위한 코드
 }

--- a/src/main/java/com/p1/nomnom/user/dto/SignupRequestDto.java
+++ b/src/main/java/com/p1/nomnom/user/dto/SignupRequestDto.java
@@ -1,0 +1,38 @@
+package com.p1.nomnom.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SignupRequestDto {
+
+    @NotBlank(message = "사용자 이름은 필수 입력 항목입니다.")
+    @Size(min = 4, max = 10, message = "사용자 이름은 4자 이상, 10자 이하로 입력해주세요.")
+    @Pattern(regexp = "^[a-z0-9]+$", message = "사용자 이름은 알파벳 소문자(a~z)와 숫자(0~9)만 사용할 수 있습니다.")
+    private String username;
+
+    @NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
+    @Size(min = 8, max = 15, message = "비밀번호는 8자 이상, 15자 이하로 입력해주세요.")
+    @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]+$",
+            message = "비밀번호는 대소문자, 숫자, 특수문자를 포함해야 합니다.")
+    private String password;
+
+    @NotBlank(message = "비밀번호 확인란은 필수 입력 항목입니다.")
+    private String passwordCheck;
+
+    @NotBlank(message = "이메일은 필수 입력 항목입니다.")
+    @Email(message = "유효한 이메일 형식을 입력해주세요.")
+    private String email;
+
+    @NotBlank(message = "휴대폰 번호는 필수 입력 항목입니다.")
+    @Pattern(regexp = "^\\d{10,11}$", message = "휴대폰 번호는 10~11자리 숫자로 입력해야 합니다.")
+    private String phone;
+
+    @NotBlank(message = "주소는 필수 입력 항목입니다.")
+    private String address;
+}

--- a/src/main/java/com/p1/nomnom/user/entity/RefreshToken.java
+++ b/src/main/java/com/p1/nomnom/user/entity/RefreshToken.java
@@ -1,0 +1,36 @@
+package com.p1.nomnom.user.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String username; // 사용자 식별자 (userId 대신 username 사용)
+
+    @Column(nullable = false, length = 512)
+    private String refreshToken; // Refresh Token 값
+
+    @Column(nullable = false)
+    private LocalDateTime expiryDate; // Refresh Token 만료 시간
+
+    // Refresh Token 업데이트 (갱신 시 사용)
+    public void updateToken(String newRefreshToken, LocalDateTime newExpiryDate) {
+        this.refreshToken = newRefreshToken;
+        this.expiryDate = newExpiryDate;
+    }
+}

--- a/src/main/java/com/p1/nomnom/user/entity/RefreshToken.java
+++ b/src/main/java/com/p1/nomnom/user/entity/RefreshToken.java
@@ -9,6 +9,7 @@ import lombok.Builder;
 import java.time.LocalDateTime;
 
 @Entity
+@Table(name = "p_refreshtoken")
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/com/p1/nomnom/user/entity/User.java
+++ b/src/main/java/com/p1/nomnom/user/entity/User.java
@@ -34,6 +34,16 @@ public class User {
     @Column(name = "is_deleted", nullable = false)
     private boolean isDeleted = false; // Soft Delete 기능
 
+    public User(String username, String email, String password, String phone, UserRoleEnum role, boolean isDeleted) {
+        this.username = username;
+        this.email = email;
+        this.password = password;
+        this.phone = phone;
+        this.role = role;
+        this.isDeleted = isDeleted;
+    }
+
+
     public void deleteUser() {
         this.isDeleted = true;
     }

--- a/src/main/java/com/p1/nomnom/user/entity/UserRoleEnum.java
+++ b/src/main/java/com/p1/nomnom/user/entity/UserRoleEnum.java
@@ -13,7 +13,7 @@ public enum UserRoleEnum {
     }
 
     public String getAuthority() {
-        return this.authority;
+        return authority;
     }
 
     public static class Authority {

--- a/src/main/java/com/p1/nomnom/user/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/p1/nomnom/user/repository/RefreshTokenRepository.java
@@ -1,0 +1,12 @@
+package com.p1.nomnom.user.repository;
+
+import com.p1.nomnom.user.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByUsername(String username); // username을 기준으로 토큰 조회
+    Optional<RefreshToken> findByRefreshToken(String refreshToken);
+    void deleteByUsername(String username); // 로그아웃 시 Refresh Token 삭제
+}

--- a/src/main/java/com/p1/nomnom/user/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/p1/nomnom/user/repository/RefreshTokenRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
-    Optional<RefreshToken> findByUsername(String username); // username을 기준으로 토큰 조회
+    Optional<RefreshToken> findByUsername(String username);
     Optional<RefreshToken> findByRefreshToken(String refreshToken);
-    void deleteByUsername(String username); // 로그아웃 시 Refresh Token 삭제
+    void deleteByUsername(String username);
 }

--- a/src/main/java/com/p1/nomnom/user/repository/UserRepository.java
+++ b/src/main/java/com/p1/nomnom/user/repository/UserRepository.java
@@ -1,0 +1,8 @@
+package com.p1.nomnom.user.repository;
+
+import com.p1.nomnom.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+}

--- a/src/main/java/com/p1/nomnom/user/repository/UserRepository.java
+++ b/src/main/java/com/p1/nomnom/user/repository/UserRepository.java
@@ -3,6 +3,11 @@ package com.p1.nomnom.user.repository;
 import com.p1.nomnom.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
 
+    Optional<User> findByUsername(String username);
+
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/com/p1/nomnom/user/service/AuthService.java
+++ b/src/main/java/com/p1/nomnom/user/service/AuthService.java
@@ -10,12 +10,17 @@ import com.p1.nomnom.user.repository.RefreshTokenRepository;
 import com.p1.nomnom.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AuthService {
@@ -26,61 +31,57 @@ public class AuthService {
     private final JwtUtil jwtUtil;
     private final AuthenticationManager authenticationManager;
 
-    // 회원가입 로직
+    @Value("${admin.code}") // ADMIN 코드 환경 변수
+    private String ADMIN_CODE;
+
+    // 회원가입
     @Transactional
     public void signup(SignupRequestDto requestDto) {
-        String username = requestDto.getUsername();
-        String email = requestDto.getEmail();
-        String phone = requestDto.getPhone();
-        String address = requestDto.getAddress();
-        String password = requestDto.getPassword();
-        String passwordCheck = requestDto.getPasswordCheck();
-
-        // 비밀번호 일치 확인
-        if (!password.equals(passwordCheck)) {
-            throw new IllegalArgumentException("비밀번호와 비밀번호 확인 값이 일치하지 않습니다.");
+        if (userRepository.findByUsername(requestDto.getUsername()).isPresent()) {
+            throw new IllegalArgumentException("이미 존재하는 사용자입니다.");
         }
 
-        // 중복 검사
-        if (userRepository.findByUsername(username).isPresent()) {
-            throw new IllegalArgumentException("이미 존재하는 사용자 이름입니다.");
-        }
-        if (userRepository.findByEmail(email).isPresent()) {
-            throw new IllegalArgumentException("이미 존재하는 이메일입니다.");
-        }
+        UserRoleEnum role = requestDto.getAdminCode() != null && requestDto.getAdminCode().equals(ADMIN_CODE)
+                ? UserRoleEnum.MASTER
+                : UserRoleEnum.CUSTOMER;
 
-        // 비밀번호 암호화
-        String encodedPassword = passwordEncoder.encode(password);
-
-        // 기본 권한 설정
-        UserRoleEnum role = UserRoleEnum.CUSTOMER;
-
-        // 사용자 저장
-        User user = new User(username, email, encodedPassword, phone, role, false);
+        User user = new User(
+                requestDto.getUsername(),
+                requestDto.getEmail(),
+                passwordEncoder.encode(requestDto.getPassword()),
+                requestDto.getPhone(),
+                role,
+                false
+        );
         userRepository.save(user);
     }
 
-    // 로그인 로직 (AccessToken & RefreshToken 발급)
+    // 로그인
     @Transactional
     public String login(LoginRequestDto requestDto) {
-        Authentication authentication = authenticationManager.authenticate(
-                new UsernamePasswordAuthenticationToken(
-                        requestDto.getUsername(),
-                        requestDto.getPassword()
-                )
+        authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(requestDto.getUsername(), requestDto.getPassword())
         );
 
-        // 사용자 정보 조회
         User user = userRepository.findByUsername(requestDto.getUsername())
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
 
-        // JWT 토큰 생성
-        String accessToken = jwtUtil.createAccessToken(user.getUsername(), user.getRole());
-        RefreshToken refreshToken = jwtUtil.createRefreshToken(user.getUsername());
-
-        // RefreshToken 저장 (기존 토큰이 있다면 업데이트)
-        refreshTokenRepository.save(refreshToken);
-
-        return "Bearer " + accessToken;
+        return jwtUtil.createAccessToken(user.getUsername(), user.getRole());
     }
+
+    // RefreshToken 생성 및 저장
+    @Transactional
+    public String generateAndSaveRefreshToken(String username) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+        return jwtUtil.createRefreshToken(user.getUsername(), user.getRole()).getRefreshToken();
+    }
+
+    // RefreshToken을 이용한 AccessToken 재발급
+    @Transactional
+    public String refreshAccessToken(String refreshToken) {
+        return jwtUtil.refreshAccessToken(refreshToken);
+    }
+
 }

--- a/src/main/java/com/p1/nomnom/user/service/AuthService.java
+++ b/src/main/java/com/p1/nomnom/user/service/AuthService.java
@@ -1,0 +1,86 @@
+package com.p1.nomnom.user.service;
+
+import com.p1.nomnom.security.jwt.JwtUtil;
+import com.p1.nomnom.user.dto.LoginRequestDto;
+import com.p1.nomnom.user.dto.SignupRequestDto;
+import com.p1.nomnom.user.entity.RefreshToken;
+import com.p1.nomnom.user.entity.User;
+import com.p1.nomnom.user.entity.UserRoleEnum;
+import com.p1.nomnom.user.repository.RefreshTokenRepository;
+import com.p1.nomnom.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtUtil jwtUtil;
+    private final AuthenticationManager authenticationManager;
+
+    // 회원가입 로직
+    @Transactional
+    public void signup(SignupRequestDto requestDto) {
+        String username = requestDto.getUsername();
+        String email = requestDto.getEmail();
+        String phone = requestDto.getPhone();
+        String address = requestDto.getAddress();
+        String password = requestDto.getPassword();
+        String passwordCheck = requestDto.getPasswordCheck();
+
+        // 비밀번호 일치 확인
+        if (!password.equals(passwordCheck)) {
+            throw new IllegalArgumentException("비밀번호와 비밀번호 확인 값이 일치하지 않습니다.");
+        }
+
+        // 중복 검사
+        if (userRepository.findByUsername(username).isPresent()) {
+            throw new IllegalArgumentException("이미 존재하는 사용자 이름입니다.");
+        }
+        if (userRepository.findByEmail(email).isPresent()) {
+            throw new IllegalArgumentException("이미 존재하는 이메일입니다.");
+        }
+
+        // 비밀번호 암호화
+        String encodedPassword = passwordEncoder.encode(password);
+
+        // 기본 권한 설정
+        UserRoleEnum role = UserRoleEnum.CUSTOMER;
+
+        // 사용자 저장
+        User user = new User(username, email, encodedPassword, phone, role, false);
+        userRepository.save(user);
+    }
+
+    // 로그인 로직 (AccessToken & RefreshToken 발급)
+    @Transactional
+    public String login(LoginRequestDto requestDto) {
+        Authentication authentication = authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(
+                        requestDto.getUsername(),
+                        requestDto.getPassword()
+                )
+        );
+
+        // 사용자 정보 조회
+        User user = userRepository.findByUsername(requestDto.getUsername())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+        // JWT 토큰 생성
+        String accessToken = jwtUtil.createAccessToken(user.getUsername(), user.getRole());
+        RefreshToken refreshToken = jwtUtil.createRefreshToken(user.getUsername());
+
+        // RefreshToken 저장 (기존 토큰이 있다면 업데이트)
+        refreshTokenRepository.save(refreshToken);
+
+        return "Bearer " + accessToken;
+    }
+}

--- a/src/main/java/com/p1/nomnom/user/service/UserService.java
+++ b/src/main/java/com/p1/nomnom/user/service/UserService.java
@@ -1,0 +1,38 @@
+package com.p1.nomnom.user.service;
+
+import com.p1.nomnom.user.dto.RoleUpdateRequestDto;
+import com.p1.nomnom.user.entity.User;
+import com.p1.nomnom.user.entity.UserRoleEnum;
+import com.p1.nomnom.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void changeUserRole(RoleUpdateRequestDto requestDto) {
+        // 변경할 사용자 조회
+        User user = userRepository.findByUsername(requestDto.getUsername())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."));
+
+        // CUSTOMER만 OWNER 또는 MANAGER로 변경 가능
+        if (user.getRole() != UserRoleEnum.CUSTOMER) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "이미 OWNER 또는 MANAGER인 사용자는 변경할 수 없습니다.");
+        }
+
+        // 새로운 권한으로 변경
+        UserRoleEnum newRole = UserRoleEnum.valueOf(requestDto.getNewRole());
+        user.setRole(newRole);
+        userRepository.save(user);
+        log.info("사용자 {}의 권한이 {}로 변경되었습니다.", user.getUsername(), newRole);
+    }
+}


### PR DESCRIPTION
## PR 체크리스트
-  커밋 컨벤션에 맞게 작성했는가?
-  PR 전에 현재 브랜치를 pull 받았는가?
-  구현한 기술들을 문서화 하였는가?

<br>

## PR 작업 분류

<!-- Please check the one that applies to this PR using "x". -->

- [ x ] 신규 기능
- [ x ] 버그 수정
- [ x ] 리팩토링
- [ x ] 기타


<br>

## 작업 상세 내용
<commit1>
[[feat]:JwtUtil, Spring Security 인증/인가 필터 기능 구현, WebSecurityConfig 구현
[WIP(Work In Progress(진행중)]:RefreshToken엔티티, Repository 작업중!
[docs]:Global_gitignore 파일 수정

=> 25.02.15~16(토,일) 작업 내용
1. JwtUtil, JwtAuthenticationFilter, JwtAuthorizationFilter, WebsecurityConfig, UserDetailsImpl, UserDetailsServiceImpl 구현과정에서 단순한 JWT토큰 생성/발급 과정 구현,,
2. RefreshToken을 User엔티티에 저장하는 방식으로 개발했다가 RefreshToken엔티티를 따로 만들어서 refresh토큰을 db에 저장하는 방식으로 변경!!(WIP: 진행중)
3. Global_gitignore에
4. !src/main/resources/
5. !src/main/resources/.keep => resources파일은 유지하되, .keep 빈 파일을 git이 추적을 안하는 방식으로 설정함.

<commit2>
[[feat]:RefreshToken 생성/AccessToken 발급 로직 구현
[Refactor]:RefreshToken Entity생성, RefreshTokenRepository리팩토링
[fix]:security/ 안에 있는 모든 security인증/인가 메소드들을 RefreshToken위주로 다시 수정
[feat2]:로그인/회원가입 로직 구현(AuthService,UserController)
[Refactor2]: User엔티티 리팩토링, LoginRequestDto, SignupRequestDto 리팩토링

=> 25.02.16,17(일,월) 작업 내용

1. RefreshToken 엔티티, RefreshTokenRepository 리팩토링
2. security/ 패키지 안에 있는 AccessToken/RefreshToken 인증/인가 방식 메소드들을 Jwt인증/인가 필터를 거쳐 UserDetailsServiceImpl과 AuthenticationManager를 불러오는 로직 흐름으로 대폭 수정.
3. Access/Refresh 토큰 발급 로직 구현
4. 로그인/회원가입 API 구현 => JwtUtil클래스에 있는 토큰 생성/저장 메소드들을 불러오고, WebsecurityConfig 파일에 spring security가 접근할 수 있도록 FilterChain 메소드안에 권한 설정 및 API URI권한 설정
5.  Authservice, Userservice 분리!! (AuthService에는 로그인/회원가입 주요 기능만,,)
6. User 엔티티, LoginRequestDto, SignupRequestDto 리팩토링(로그인/회원가입 API에 집중)

<commit3>
[[Refactor]:Access토큰/Refresh토큰 재생성 테스트 위해 리펙토링

=> 25.02.17(월) 작업 내용
: 테스트 과정에서 일어나는 에러 및 이슈 해결

1. 엔티티 및 Dto 수정(RefreshToken기준) => RefreshToken은 @Builder 사용(변경이 적기 때문,,) 
2. security/ 패키지에서 log 찍어가며 예외처리 생성 흐름으로 진행.
3. AccessToken 만료시 기존에 생성된 RefreshToken으로 재생성 기능 API 테스트 진행!
4. refreshToken기반 AccessToken재생성 메소드, requestHeader에서 RefreshToken값 추출 (Bearer ) 제거 로직 통일 작업 진행.
5. 기존: username만을 기준으로 인증/인가 ,, 수정 후: username, role 두 개를 기준으로 인증/인가

<commit4>
[[Refactor]:로그인/회원가입 기능 테스트 도중 발생한 에러 해결 위해 리팩토링

=> 25.02.17(월) 작업 내용
: 테스트 과정에서 일어나는 에러 및 이슈 해결

1. 엔티티 및 Dto 수정(로그인/회원가입 API) => db생성 및 토큰 생성 및 저장은 아주 잘 되는 것으로 테스트 완료했으나, Postman에서 Response body부분에 JSON데이터로 안넘어오는 이슈.

<commit5>
[[feat]:Spring AOP기반 @RoleCheck어노테이션 커스터마이징 기능 구현
1. Spring security vs AOP 기능 중에 고민하다가, 단순하게 security 기능 사용보다 직접 우리 서비스의 요구사항에 커스터마이징 하기 위해 AOP를 이용해 더 유연한 방식으로 권한체크 구현!
=> aop/ 안에 구현
2. AdminController, UserService 생성
=> MASTER(ADMIN) 가 직접, 기본 디폴트 role인 CUSTOMER를 OWNER, MANAGER로 권한 승격 API 기능 추가로 역할 변경 가능!!

&팀원들이 숙지해야 할 @RoleCheck 사용법&
=> Service, Controller에서 모두 사용 가능!!
// ✅ CUSTOMER, OWNER, MASTER만 접근 가능
    @RoleCheck(roles = {"CUSTOMER", "OWNER", "MASTER"})

// ✅ OWNER, MASTER만 접근 가능
    @RoleCheck(roles = {"OWNER", "MASTER"})

// ✅ MASTER만 접근 가능
    @RoleCheck(roles = {"MASTER"})



<br>

## 🔴 이건 반드시 확인해 주세요!
